### PR TITLE
Feature: Handle nested paths in mongoose Schema

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var async = require('async');
+var dotProp = require('dot-prop');
 var counterSchema = require('./counterSchema');
 
 var init = function (db) {
@@ -36,7 +37,7 @@ var plugin = function (schema, model) {
                 var name = model + '.' + item;
 
                 Counter.getNextCount(name, function (err, count) {
-                    ins[item] = count;
+                    dotProp.set(ins, item, count);
 
                     callback(err);
                 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mongoose-auto-number",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Mongoose plugin to auto increment numeric field",
     "main": "lib/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     ],
     "peerDependencies": {
         "async": "^2.3.0",
+        "dot-prop": "^6.0.1",
         "mongoose": "^5.x"
     }
 }


### PR DESCRIPTION
Handle nested paths by using a Nested Object Setter instead of ins[item] = count.