### PR TITLE
v1.0.5: Ensure that name of counter docs are lowercase

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ var plugin = function (schema, model) {
             fieldToUpdate,
             function (item, callback) {
 
-                var name = model + '.' + item;
+                var name = (model + '.' + item).toLowerCase();
 
                 Counter.getNextCount(name, function (err, count) {
                     dotProp.set(ins, item, count);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mongoose-auto-number",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Mongoose plugin to auto increment numeric field",
     "main": "lib/index.js",
     "scripts": {


### PR DESCRIPTION
Related to Taiga Issue #6060

**Purpose:** 
Ensure that name of counter docs are lowercase as defined in Counter

**Bug:**
Two counters per path with autoIncrement: true were being created instead of one.
- 1 normal case (e.g Ticket.ticketNo)
- 1 lowercase (e.g. ticket.ticketno) 

**Solution:**
Execute toLowerCase() function onto name of Counter before creation or update