### PR TITLE
v1.0.6: Add "_ignore.<fieldname>" option to ignore update of Counter for some cases

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,9 +19,6 @@ var plugin = function (schema, model) {
 
     schema.pre('save', function (next) {
 
-        if (this._ignoreAutoIncrement)
-            return next()
-
         var ins = this;
 
         var fieldToUpdate = [];
@@ -36,6 +33,11 @@ var plugin = function (schema, model) {
         async.each(
             fieldToUpdate,
             function (item, callback) {
+
+                var ignoreField = '_ignore.' + item;
+
+                if (this[ignoreField])
+                    return callback()
 
                 var name = (model + '.' + item).toLowerCase();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,9 @@ var plugin = function (schema, model) {
 
     schema.pre('save', function (next) {
 
+        if (this._ignoreAutoIncrement)
+            return next()
+
         var ins = this;
 
         var fieldToUpdate = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mongoose-auto-number",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "Mongoose plugin to auto increment numeric field",
     "main": "lib/index.js",
     "scripts": {


### PR DESCRIPTION
Feature:
Add "_ignore.<fieldname>" option to ignore update of Counter for some cases

How it's used:
![image](https://user-images.githubusercontent.com/20681851/156321298-8c0f48c3-582d-4889-9998-292191d0477e.png)

Motivation:
In some cases, we don't know to auto-increment a field.
For e.g. if we have a field clientNo to be autoincremented, we would only want to increment the field if type=client.